### PR TITLE
Themekit upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "eslint ./ --fix && prettier-stylelint **/*.scss",
     "lint:fix-js": "eslint ./ --fix",
     "lint:fix-styles": "prettier-stylelint --write",
-    "bootstrap": "yarn install && lerna bootstrap",
+    "bootstrap": "npm install && lerna bootstrap",
     "changelog": "node_modules/.bin/lerna-changelog",
     "clean": "lerna clean",
     "build": "lerna run build",

--- a/packages/slate-sync/index.js
+++ b/packages/slate-sync/index.js
@@ -92,57 +92,49 @@ async function deploy(cmd = '', files = []) {
   return maybeDeploy;
 }
 
-function promiseThemekitConfig() {
-  return new Promise((resolve, reject) => {
-    const configFlags = _generateConfigFlags();
+async function promiseThemekitConfig() {
+  const configFlags = _generateConfigFlags();
 
-    try {
-      themekit.command(
-        'configure',
-        configFlags,
-        {
-          cwd: config.get('paths.theme.dist')
-        }
-      );
-      resolve();
-    } catch (error) {
-      console.error('My Error', error);
-      reject(error);
-    }
-  })
+  try {
+    await themekit.command(
+      'configure',
+      configFlags,
+      {
+        cwd: config.get('paths.theme.dist')
+      }
+    );
+  } catch (error) {
+    console.error('My Error', error);
+  }
 }
 
-function promiseThemekitDeploy(cmd, files) {
-  return new Promise((resolve, reject) => {
-    const configFlags = _generateConfigFlags();
+async function promiseThemekitDeploy(cmd, files) {
+  const configFlags = _generateConfigFlags();
 
-    if (files) {
-      configFlags['files'] = files
-    }
+  if (files) {
+    configFlags['files'] = files
+  }
 
-    if (cmd == "upload") {
-      configFlags['noDelete'] = true
-    }
+  if (cmd == "upload") {
+    configFlags['noDelete'] = true
+  }
 
-    try {
-      themekit.command(
-        'deploy',
-        configFlags,
-        {
-          cwd: config.get('paths.theme.dist')
-        }
-      );
-      resolve();
-    } catch (error) {
-      console.error('My Error', error);
-      reject(error);
-    }
-  });
   // slate-tools `deploy` command already prompts user
   // if they want to deploy to published theme,
   // so they only get here if they approve`
   configFlags['allow-live'] = true
 
+  try {
+    await themekit.command(
+      'deploy',
+      configFlags,
+      {
+        cwd: config.get('paths.theme.dist')
+      }
+    );
+  } catch (error) {
+    console.error('My Error', error);
+  }
 }
 
 /**

--- a/packages/slate-sync/index.js
+++ b/packages/slate-sync/index.js
@@ -138,6 +138,11 @@ function promiseThemekitDeploy(cmd, files) {
       reject(error);
     }
   });
+  // slate-tools `deploy` command already prompts user
+  // if they want to deploy to published theme,
+  // so they only get here if they approve`
+  configFlags['allow-live'] = true
+
 }
 
 /**

--- a/packages/slate-sync/index.js
+++ b/packages/slate-sync/index.js
@@ -109,7 +109,7 @@ function promiseThemekitConfig() {
       console.error('My Error', error);
       reject(error);
     }
-  }) //.catch(error => { console.log('caught', error.message); });
+  })
 }
 
 function promiseThemekitDeploy(cmd, files) {

--- a/packages/slate-sync/package.json
+++ b/packages/slate-sync/package.json
@@ -14,7 +14,7 @@
     "@shopify/slate-analytics": "1.0.0-beta.16",
     "@shopify/slate-config": "1.0.0-beta.14",
     "@shopify/slate-env": "1.0.0-beta.16",
-    "@shopify/themekit": "0.6.12",
+    "@shopify/themekit": "^1.1.6",
     "array-flatten": "^2.1.1",
     "chalk": "2.3.2",
     "figures": "^2.0.0",


### PR DESCRIPTION
# Goal 
## Upgrade Slate to latest Themekit (for fun and profit)
- Actually, mostly because the new Themekit calculates hashes on files so it doesn't transfer files if it doesn't need to

### 0.6.12 -> ^1.1.6

- the new Themekit API is a bit different, so required changing the arguments structure

#### old
- https://github.com/Shopify/node-themekit/blob/c8c87641c05783c416a2e6b356887cf37bf65440/lib/command.js
<img width="348" alt="Screen Shot 2021-04-05 at 10 55 37 AM" src="https://user-images.githubusercontent.com/608048/113587924-79f07b80-95fd-11eb-9d51-cdf81dde6225.png">
...

#### new
  - https://github.com/Shopify/node-themekit/blob/master/lib/themekit.js

<img width="570" alt="Screen Shot 2021-04-05 at 10 47 45 AM" src="https://user-images.githubusercontent.com/608048/113587156-67297700-95fc-11eb-8ee0-d772f48c3d0e.png">
 

- also, promises are returned, so we can use async/await pattern to clean things up a bit
  - https://github.com/Shopify/node-themekit/blob/master/lib/run-executable.js
