### PR TITLE
Feature/remove analytics part1 redux

### DIFF
--- a/packages/slate-tools/cli/commands/build.js
+++ b/packages/slate-tools/cli/commands/build.js
@@ -8,20 +8,11 @@ process.env.NODE_ENV = 'production';
  * If the `deploy` argument has been passed, deploy to Shopify when the compilation is done.
  */
 const webpack = require('webpack');
-const {event} = require('@shopify/slate-analytics');
 const webpackConfig = require('../../tools/webpack/config/prod');
 const packageJson = require('../../package.json');
 
-event('slate-tools:build:start', {
-  version: packageJson.version,
-});
-
 webpack(webpackConfig, (err, stats) => {
   if (err) throw err;
-
-  event('slate-tools:build:end', {
-    version: packageJson.version,
-  });
 
   process.stdout.write(
     `${stats.toString({

--- a/packages/slate-tools/cli/commands/deploy.js
+++ b/packages/slate-tools/cli/commands/deploy.js
@@ -1,12 +1,9 @@
 const argv = require('minimist')(process.argv.slice(2));
 const chalk = require('chalk');
-const {event} = require('@shopify/slate-analytics');
 const {replace, upload} = require('@shopify/slate-sync');
 
 const packageJson = require('../../package.json');
 const promptContinueIfPublishedTheme = require('../prompts/continue-if-published-theme');
-
-event('slate-tools:deploy:start', {version: packageJson.version});
 
 const deploy = argv.replace ? replace : upload;
 
@@ -19,13 +16,8 @@ promptContinueIfPublishedTheme()
     return deploy();
   })
   .then(() => {
-    event('slate-tools:deploy:end', {version: packageJson.version});
     return console.log(chalk.green('\nFiles overwritten successfully!\n'));
   })
   .catch((error) => {
-    event('slate-tools:deploy:error', {
-      version: packageJson.version,
-      error,
-    });
     console.log(`\n${chalk.red(error)}\n`);
   });

--- a/packages/slate-tools/cli/commands/start.js
+++ b/packages/slate-tools/cli/commands/start.js
@@ -10,7 +10,6 @@ const consoleControl = require('console-control-strings');
 const clearConsole = require('react-dev-utils/clearConsole');
 const ip = require('ip');
 const env = require('@shopify/slate-env');
-const {event} = require('@shopify/slate-analytics');
 const SlateConfig = require('@shopify/slate-config');
 
 const promptContinueIfPublishedTheme = require('../prompts/continue-if-published-theme');
@@ -33,8 +32,6 @@ let continueIfPublishedTheme = null;
 let assetServer;
 let devServer;
 let previewUrl;
-
-event('slate-tools:start:start', {version: packageJson.version});
 
 Promise.all([
   getAvailablePortSeries(config.get('network.startPort'), 3),
@@ -93,11 +90,6 @@ function onCompilerDone(stats) {
   }
 
   if (statsJson.errors.length) {
-    event('slate-tools:start:compile-errors', {
-      errors: statsJson.errors,
-      version: packageJson.version,
-    });
-
     console.log(chalk.red('Failed to compile.\n'));
 
     statsJson.errors.forEach((message) => {
@@ -106,12 +98,6 @@ function onCompilerDone(stats) {
   }
 
   if (statsJson.warnings.length) {
-    event('slate-tools:start:compile-warnings', {
-      duration: statsJson.time,
-      warnings: statsJson.warnings,
-      version: packageJson.version,
-    });
-
     console.log(chalk.yellow('Compiled with warnings.\n'));
 
     statsJson.warnings.forEach((message) => {
@@ -120,10 +106,6 @@ function onCompilerDone(stats) {
   }
 
   if (!statsJson.errors.length && !statsJson.warnings.length) {
-    event('slate-tools:start:compile-success', {
-      duration: statsJson.time,
-      version: packageJson.version,
-    });
 
     console.log(
       `${chalk.green(figures.tick)}  Compiled successfully in ${statsJson.time /
@@ -143,10 +125,6 @@ async function onClientBeforeSync(files) {
     try {
       continueIfPublishedTheme = await promptContinueIfPublishedTheme();
     } catch (error) {
-      event('slate-tools:start:error', {
-        version: packageJson.version,
-        error,
-      });
       console.log(`\n${chalk.red(error)}\n`);
     }
   }
@@ -169,10 +147,6 @@ async function onClientBeforeSync(files) {
 function onClientSyncSkipped() {
   if (!(firstSync && argv.skipFirstDeploy)) return;
 
-  event('slate-tools:start:skip-first-deploy', {
-    version: packageJson.version,
-  });
-
   console.log(
     `\n${chalk.blue(
       figures.info,
@@ -181,12 +155,9 @@ function onClientSyncSkipped() {
 }
 
 function onClientSync() {
-  event('slate-tools:start:sync-start', {version: packageJson.version});
 }
 
 function onClientSyncDone() {
-  event('slate-tools:start:sync-end', {version: packageJson.version});
-
   process.stdout.write(consoleControl.previousLine(4));
   process.stdout.write(consoleControl.eraseData());
 

--- a/packages/slate-tools/cli/commands/zip.js
+++ b/packages/slate-tools/cli/commands/zip.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 const path = require('path');
 const archiver = require('archiver');
 const chalk = require('chalk');
-const {event} = require('@shopify/slate-analytics');
 const SlateConfig = require('@shopify/slate-config');
 
 const config = new SlateConfig(require('../../slate-tools.schema'));
@@ -19,8 +18,6 @@ const zipPath = getZipPath(config.get('paths.theme'), zipName, 'zip');
 const output = fs.createWriteStream(zipPath);
 const archive = archiver('zip');
 
-event('slate-tools:zip:start');
-
 if (!fs.existsSync(config.get('paths.theme.dist'))) {
   console.log(
     chalk.red(
@@ -33,7 +30,6 @@ if (!fs.existsSync(config.get('paths.theme.dist'))) {
 }
 
 output.on('close', () => {
-  event('slate-tools:zip:end', {size: archive.pointer()});
   console.log(`${path.basename(zipPath)}: ${archive.pointer()} total bytes`);
 });
 

--- a/packages/slate-tools/cli/index.js
+++ b/packages/slate-tools/cli/index.js
@@ -2,7 +2,6 @@
 const spawn = require('cross-spawn');
 const chalk = require('chalk');
 const argv = require('minimist')(process.argv.slice(2));
-const analytics = require('@shopify/slate-analytics');
 const SlateConfig = require('@shopify/slate-config');
 const slateEnv = require('@shopify/slate-env');
 const packageJson = require('../package.json');
@@ -23,8 +22,6 @@ let result;
 async function init() {
   let slateConfig;
 
-  await analytics.init();
-
   // Convert user config to JSON string so it can be sent in analytics. Make sure
   // we catch any errors while converting, such as converting a circular object
   // structure to JSON
@@ -33,11 +30,6 @@ async function init() {
   } catch (error) {
     slateConfig = JSON.stringify({error: error.message});
   }
-
-  analytics.event('slate-tools:cli:start', {
-    slateConfig,
-    version: packageJson.version,
-  });
 
   switch (script) {
     case 'build':

--- a/packages/slate-tools/cli/prompts/continue-if-published-theme.js
+++ b/packages/slate-tools/cli/prompts/continue-if-published-theme.js
@@ -2,7 +2,6 @@
 const chalk = require('chalk');
 const inquirer = require('inquirer');
 const slateEnv = require('@shopify/slate-env');
-const {event} = require('@shopify/slate-analytics');
 const {fetchMainThemeId} = require('@shopify/slate-sync');
 const figures = require('figures');
 const {argv} = require('yargs');

--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -14,7 +14,6 @@
   "engine": ">=8.9.4",
   "dependencies": {
     "@shopify/html-webpack-liquid-asset-tags-plugin": "1.0.0-beta.11",
-    "@shopify/slate-analytics": "1.0.0-beta.16",
     "@shopify/slate-config": "1.0.0-beta.14",
     "@shopify/slate-cssvar-loader": "1.0.0-beta.16",
     "@shopify/slate-env": "1.0.0-beta.16",

--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -23,7 +23,7 @@
     "@shopify/slate-tag-webpack-plugin": "1.0.0-beta.14",
     "@shopify/slate-translations": "1.0.0-beta.19",
     "@shopify/theme-lint": "^2.0.0",
-    "@shopify/themekit": "0.6.12",
+    "@shopify/themekit": "^1.1.6",
     "archiver": "^2.1.0",
     "array-flatten": "^2.1.1",
     "autoprefixer": "6.7.7",


### PR DESCRIPTION
# Goal
## Remove Slate Analytics from Slate-Tools command usage
Ultimately, the call to the analytics endpoint returns 404 and Slate is deprecated so no reason not to remove.

This is the first step before removing it completely in another PR.